### PR TITLE
(fix/top-bar-botão-nova-consulta-calendario-datas): Ajeitar incoerênc…

### DIFF
--- a/client/src/app/page-atendimento/page.tsx
+++ b/client/src/app/page-atendimento/page.tsx
@@ -243,14 +243,18 @@ const PageAtendimento = () => {
             <Button
               variant="link"
               onClick={() => setModoExibicao("historico")}
-              className={`flex items-center justify-center h-[42px] w-[92px] rounded-[8px] hover:no-underline focus:outline-none focus:ring-0 ${modoExibicao === "historico" ? "bg-white" : "bg-[#F0F0F0]"}`}
+              className={`flex items-center justify-center h-[42px] w-[92px] rounded-[8px] hover:no-underline focus:outline-none focus:ring-0 ${
+                modoExibicao === "historico" ? "bg-white" : "bg-[#F0F0F0]"
+              }`}
             >
               <p>Histórico</p>
             </Button>
             <Button
               variant="link"
               onClick={() => setModoExibicao("agendamento")}
-              className={`flex items-center justify-center h-[42px] w-[127px] rounded-[8px] hover:no-underline focus:outline-none focus:ring-0 ${modoExibicao === "agendamento" ? "bg-white" : "bg-[#F0F0F0]"}`}
+              className={`flex items-center justify-center h-[42px] w-[127px] rounded-[8px] hover:no-underline focus:outline-none focus:ring-0 ${
+                modoExibicao === "agendamento" ? "bg-white" : "bg-[#F0F0F0]"
+              }`}
             >
               <p>Agendamento</p>
             </Button>
@@ -301,7 +305,10 @@ const PageAtendimento = () => {
 
         {/* Botão nova consulta */}
         <div className="flex justify-end w-full mt-[153px]">
-          <Button className="h-[48px] w-[205px] bg-[#50E678] rounded-[24px] py-[12px] px-[32px] gap-[10px] shadow-[0_4px_4px_#0000001A] hover:bg-[#50E678]/80">
+          <Button
+            className="h-[48px] w-[205px] bg-[#50E678] rounded-[24px] py-[12px] px-[32px] gap-[10px] shadow-[0_4px_4px_#0000001A] hover:bg-[#50E678]/80"
+            onClick={() => router.push("/page-cadastro")}
+          >
             <Image src={PlusCircled} alt="Plus Circled Icon" />
             Nova Consulta
           </Button>

--- a/client/src/components/top-bar/index.tsx
+++ b/client/src/components/top-bar/index.tsx
@@ -1,35 +1,61 @@
 'use client'
 
 import React from 'react';
-import { finalTopBar } from '@/assets';
-import { LogoCITiPet } from '@/assets';
+import { finalTopBar, LogoCITiPet } from '@/assets';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 function TopBar() {
-    const router = useRouter();
-    return (
-        <div 
-            className = "w-full bg-white flex items-center justify-center border-b border-[#D9D9D9] h-[114px] pl-[48px] pr-[48px] pt-[20px] pb-[20px]">
-            <div className = "flex flex-1 justify-center items-center gap-20">
-                <button className = "text-lg text-black hover:underline decoration-[#50E678] decoration-2 w-[86px] h-[42px] flex items-center justify-center" onClick={() => router.push('/page-atendimento')}> Atendimento </button>
-                
-                <Image className = "w-[189px] h-[74px]"
-                    src={LogoCITiPet}
-                    alt="Logo CITiPet"
-                />
-                
-                <button className = "text-lg text-black hover:underline decoration-[#50E678] decoration-2 w-[62px] h-[42px] flex items-center justify-center" onClick={() => router.push('/page-cadastro')}> Cadastro </button>
-            </div>
-            
-            <div className = "absolute right-0 px-[48px]">
-                <Image className = "w-[220px] h-[24px]"
-                    src={finalTopBar}
-                    alt="Final Top Bar"
-                />
-            </div>
-        </div>
-    );
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Verifica se estamos em "Atendimento" ou "Detalhes da Consulta"
+  const isAtendimentoActive =
+    pathname.startsWith('/page-atendimento') ||
+    pathname.startsWith('/page-detalhes-consulta');
+
+  // Verifica se estamos em "Cadastro"
+  const isCadastroActive = pathname === '/page-cadastro';
+
+  return (
+    <div className="w-full bg-white flex items-center justify-center border-b border-[#D9D9D9] h-[114px] pl-[48px] pr-[48px] pt-[20px] pb-[20px]">
+      <div className="flex flex-1 justify-center items-center gap-20">
+        <button
+          className={`
+            text-lg text-black w-[86px] h-[42px] flex items-center justify-center
+            ${isAtendimentoActive ? 'underline decoration-[#50E678] decoration-2' : ''}
+          `}
+          onClick={() => router.push('/page-atendimento')}
+        >
+          Atendimento
+        </button>
+
+        <Image
+          className="w-[189px] h-[74px]"
+          src={LogoCITiPet}
+          alt="Logo CITiPet"
+        />
+
+        <button
+          className={`
+            text-lg text-black w-[62px] h-[42px] flex items-center justify-center
+            ${isCadastroActive ? 'underline decoration-[#50E678] decoration-2' : ''}
+          `}
+          onClick={() => router.push('/page-cadastro')}
+        >
+          Cadastro
+        </button>
+      </div>
+
+      <div className="absolute right-0 px-[48px]">
+        <Image
+          className="w-[220px] h-[24px]"
+          src={finalTopBar}
+          alt="Final Top Bar"
+        />
+      </div>
+    </div>
+  );
 }
 
 export default TopBar;

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -81,5 +81,6 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   display: none;
   -webkit-appearance: none;
   opacity: 0;
+  
 }
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.1",
     "@expo-google-fonts/barlow": "^0.2.3",
+    "@expo/metro-runtime": "~5.0.4",
     "babel-preset-expo": "^13.0.0",
     "expo": "^53.0.7",
     "expo-asset": "^11.1.5",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@expo-google-fonts/barlow':
         specifier: ^0.2.3
         version: 0.2.3
+      '@expo/metro-runtime':
+        specifier: ~5.0.4
+        version: 5.0.4(react-native@0.79.2(@babel/core@7.27.1)(@types/react@19.0.14)(react@19.0.0))
       babel-preset-expo:
         specifier: ^13.0.0
         version: 13.0.0(@babel/core@7.27.1)


### PR DESCRIPTION
### Purpose:

> Fix errors in TopBar components, correctly redirect the use of the new query button on the "page-atendimento" and fix the appearance of 2 calendar icons

### What I've Done:

> Adjusted the TopBar to underline on the page that is present

> Added the correct route to the "nova-consulta" button

> Fix the 2 calendar icons

### How to test

> To test, use Thunder Client to register patients with the /page-paciente endpoint.
> A temporary modification was made to the routes.ts file to allow consultation registration (POST) with the /page-atendimento endpoint.
